### PR TITLE
update for applying patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "debug": "2.4.5",
+    "extend": "^3.0.0",
     "fast-json-patch": "1.1.3",
     "moment": "2.17.1",
     "q": "1.4.1"


### PR DESCRIPTION
When applying a patch, the code was directly changing this.values (the directly accessed values in the config object).  This has a couple problems

* This would not run the changed event lifecycle for the config in process applying the patch.  Even with refresh this' values would get changed, the store updated, refresh broadcast and the subscriber would then compare current's (this') values to those in the store.  They would of course be the same since step 1 was to update this.values.
* This approach was also not symmetrical wrt set and delete.  Those operations would only update the store and then rely on refreshing to get the changes into this.values.

This problem was preventing the inmemory configuration from being controlled by ```cc```.
